### PR TITLE
Refresh folder list after upload

### DIFF
--- a/gui/upload_tab.py
+++ b/gui/upload_tab.py
@@ -151,6 +151,7 @@ def crear_tab_subir(
                 "boton_subir": boton_subir,
                 "boton_copiar": boton_copiar,
                 "carpeta_seleccionada": carpeta_seleccionada,
+                "refs": refs,
                 "loader": loader,
                 "root": root,
             },

--- a/services/uploader.py
+++ b/services/uploader.py
@@ -5,11 +5,16 @@ import customtkinter
 
 from s3.client import actualizar_lista_buckets
 from s3.upload import subir_archivo_a_s3
+from config.aws_config import cargar_carpetas
 from widgets.loader import ocultar_loader_grid, ocultar_loader
 
 
 def subir_archivo_worker(
-    *args, loader: customtkinter.CTkProgressBar, root: customtkinter.CTk, **kwargs
+    *args,
+    loader: customtkinter.CTkProgressBar,
+    root: customtkinter.CTk,
+    refs: dict,
+    **kwargs,
 ) -> None:
     """
     Ejecuta la función subir_archivo_a_s3 en un hilo separado y oculta el loader al finalizar.
@@ -18,6 +23,7 @@ def subir_archivo_worker(
         *args: Argumentos posicionales para subir_archivo_a_s3.
         loader (CTkProgressBar): Barra de progreso a ocultar.
         root (CTk): Ventana principal, usada para volver al hilo principal.
+        refs (dict): Referencias a widgets compartidos.
         **kwargs: Argumentos con nombre para subir_archivo_a_s3.
     """
     try:
@@ -25,6 +31,7 @@ def subir_archivo_worker(
     finally:
         # volvemos al hilo principal para tocar la GUI
         root.after(0, lambda: ocultar_loader(loader))
+        root.after(0, lambda: cargar_carpetas(refs))
 
 
 def actualizar_lista_worker(


### PR DESCRIPTION
## Summary
- allow `uploader.subir_archivo_worker` to accept widget refs and refresh folder list after upload
- pass the refs dictionary when starting the upload worker thread

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685061c69ed8832b9485a5675ca7a5ad