### PR TITLE
Update folder refresh logic

### DIFF
--- a/services/uploader.py
+++ b/services/uploader.py
@@ -14,6 +14,7 @@ def subir_archivo_worker(
     loader: customtkinter.CTkProgressBar,
     root: customtkinter.CTk,
     refs: dict,
+    carpeta_seleccionada: str,
     **kwargs,
 ) -> None:
     """
@@ -24,14 +25,20 @@ def subir_archivo_worker(
         loader (CTkProgressBar): Barra de progreso a ocultar.
         root (CTk): Ventana principal, usada para volver al hilo principal.
         refs (dict): Referencias a widgets compartidos.
+        carpeta_seleccionada (str): Carpeta donde se subió el archivo.
         **kwargs: Argumentos con nombre para subir_archivo_a_s3.
     """
     try:
-        subir_archivo_a_s3(*args, **kwargs)
+        subir_archivo_a_s3(*args, carpeta_seleccionada=carpeta_seleccionada, **kwargs)
     finally:
         # volvemos al hilo principal para tocar la GUI
         root.after(0, lambda: ocultar_loader(loader))
-        root.after(0, lambda: cargar_carpetas(refs))
+        valores = []
+        if "menu_carpeta" in refs:
+            valores = list(refs["menu_carpeta"].cget("values") or [])
+        carpeta_normalizada = f"{carpeta_seleccionada.rstrip('/')}/"
+        if carpeta_normalizada not in valores:
+            root.after(0, lambda: cargar_carpetas(refs))
 
 
 def actualizar_lista_worker(


### PR DESCRIPTION
## Summary
- refresh folder list after uploads only when the uploaded folder doesn't already exist

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685061149e38832ba3467c9d90746599