### PR TITLE
Add preview support for uploaded files

### DIFF
--- a/gui/upload_tab.py
+++ b/gui/upload_tab.py
@@ -7,6 +7,7 @@ import customtkinter
 
 from services.uploader import subir_archivo_worker
 from widgets.loader import crear_loader_padre, mostrar_loader
+from widgets.preview import crear_preview
 from gui.actions import copiar_url, seleccionar_archivo, actualizar_url_preliminar
 from CTkScrollableDropdown import CTkScrollableDropdown
 
@@ -134,6 +135,7 @@ def crear_tab_subir(
     boton_seleccionar.configure(command=seleccionar_y_guardar)
 
     loader = crear_loader_padre(tab)
+    preview = crear_preview(tab)
 
     def lanzar_subida():
         mostrar_loader(loader)
@@ -175,4 +177,5 @@ def crear_tab_subir(
         "textbox_name_file": textbox_name_file,
         "menu_carpeta": menu_carpeta,
         "dropdown_carpeta": dropdown_carpeta,
+        "preview": preview,
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3
 customtkinter
+Pillow

--- a/services/uploader.py
+++ b/services/uploader.py
@@ -7,6 +7,7 @@ from s3.client import actualizar_lista_buckets
 from s3.upload import subir_archivo_a_s3
 from config.aws_config import cargar_carpetas
 from widgets.loader import ocultar_loader_grid, ocultar_loader
+from widgets.preview import mostrar_preview
 
 
 def subir_archivo_worker(
@@ -29,7 +30,12 @@ def subir_archivo_worker(
         **kwargs: Argumentos con nombre para subir_archivo_a_s3.
     """
     try:
-        subir_archivo_a_s3(*args, carpeta_seleccionada=carpeta_seleccionada, **kwargs)
+        subir_archivo_a_s3(
+            *args, carpeta_seleccionada=carpeta_seleccionada, **kwargs
+        )
+        archivo = kwargs.get("archivo_seleccionado") or (args[0] if args else None)
+        if archivo and "preview" in refs:
+            root.after(0, lambda p=archivo: mostrar_preview(refs["preview"], p))
     finally:
         # volvemos al hilo principal para tocar la GUI
         root.after(0, lambda: ocultar_loader(loader))

--- a/widgets/preview.py
+++ b/widgets/preview.py
@@ -1,0 +1,69 @@
+"""Módulo con widgets para mostrar vista previa de archivos."""
+
+from __future__ import annotations
+
+import os
+
+import customtkinter
+from PIL import Image
+
+
+def crear_preview(parent: customtkinter.CTkBaseClass) -> customtkinter.CTkFrame:
+    """Crea un frame oculto con etiquetas de información y área de imagen."""
+    frame = customtkinter.CTkFrame(parent)
+
+    label_info = customtkinter.CTkLabel(frame, text="")
+    label_info.pack(pady=(5, 0))
+
+    label_image = customtkinter.CTkLabel(frame, text="")
+    label_image.pack(pady=5)
+
+    button_hide = customtkinter.CTkButton(
+        frame, text="Cerrar", command=lambda: ocultar_preview(frame)
+    )
+    button_hide.pack(pady=(0, 5))
+
+    frame.label_info = label_info  # type: ignore[attr-defined]
+    frame.label_image = label_image  # type: ignore[attr-defined]
+
+    frame.pack(pady=10)
+    frame.pack_forget()
+    return frame
+
+
+def _format_size(size: int) -> str:
+    """Convierte un tamaño de bytes a un texto legible."""
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KB"
+    return f"{size / (1024 * 1024):.1f} MB"
+
+
+def mostrar_preview(frame: customtkinter.CTkFrame, path: str) -> None:
+    """Llena las etiquetas con datos del archivo y muestra la vista previa."""
+    if not os.path.exists(path):
+        return
+
+    size = os.path.getsize(path)
+    texto = [f"Tamaño: {_format_size(size)}"]
+
+    try:
+        img = Image.open(path)
+        texto.append(f"Dimensiones: {img.width}x{img.height}")
+        max_side = 200
+        scale = min(1.0, max_side / max(img.width, img.height))
+        preview_size = (int(img.width * scale), int(img.height * scale))
+        ctk_img = customtkinter.CTkImage(light_image=img, dark_image=img, size=preview_size)
+        frame.label_image.configure(image=ctk_img, text="")  # type: ignore[attr-defined]
+        frame.label_image.image = ctk_img  # type: ignore[attr-defined]
+    except Exception:
+        frame.label_image.configure(text="(Sin vista previa)", image=None)  # type: ignore[attr-defined]
+
+    frame.label_info.configure(text="\n".join(texto))  # type: ignore[attr-defined]
+    frame.pack(pady=10)
+
+
+def ocultar_preview(frame: customtkinter.CTkFrame) -> None:
+    """Oculta el frame de vista previa."""
+    frame.pack_forget()


### PR DESCRIPTION
## Summary
- add a new `widgets.preview` helper to display previews and info
- show preview frame in upload tab and store it in refs
- trigger preview display after successful upload
- require Pillow in dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685191c3b3b4832bb80f44f38dfb7adf